### PR TITLE
removed TODOs and Deck Sketch that are now Wiki pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,31 +5,3 @@ A small PoC of push notification technology.
 For the running application, see
 [client](https://pwa-push-demo2.azurewebsites.net/) and
 [server](https://pwa-push-demo2.azurewebsites.net/web_app/index.html)
-
-## TODOs
-* Integrate in Summit PWA Application \[MK]
-  * Need to be modified:
-    * Node.js part summit-app-nodejs
-    * PWA application - summit-app
-* Integrate timer package (job scheduler) \[MS]
-* Create Deck \[MS+MK]
-  * Constraints: 20 minutes
-    * Part I: Deck (15m)
-    * Part II: Show live app + code walkthrough (5m)
-      * Show/discuss what had to be added to the Summit App to enable push notification
-    * Part III: Questions + Discussions
-  * Details: see below
-
-## Deck Sketch
-### Architecture of Push notification
-* How does the flow work?
-* Why is it not integrated with Safari?
-
-### Integration with APNM
-* Android only?
-* maybe out-of-scope
-
-### Social Perspective
-* DOs and DONTs of push notifications
-* When to use it?
-  * Article on ...


### PR DESCRIPTION
I copied the TODO and deck ideas part of the README to individual Wiki pages. This pull request removes them from the README so we don't always have to change master and trigger a cloud rebuild when we update the TODO list or deck ideas.