### PR TITLE
added link to deck as GitHub page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ A small PoC of push notification technology.
 For the running application, see
 [client](https://pwa-push-demo2.azurewebsites.net/) and
 [server](https://pwa-push-demo2.azurewebsites.net/web_app/index.html)
+
+[Deck](https://mathiask.github.io/pwa-push-demo/index.html)


### PR DESCRIPTION
I added a link to the deck sketch as a GitHub page in my cloned repo. Unfortunately using a branch "gh-pages" in apps-evolve-summit/pwa-push-demo didn't work: the URL https://apps-evolve-summit.github.io/pwa-push-demo/index.html shows the main summit web page.

The deck is now in it's own branch "deck" already pushed to apps-evolve-summit/pwa-push-demo. It is unrelated to "master" and once you check it out you can just open it in Chrome (you don't even need to run a server). 

We could also move it to the master (or other "normal") branch, but then it's also automatically deployed to the Azure server.